### PR TITLE
add some dependecies needed back to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ A 32 bit checkm8 based downgrade utility.
 * [libirecovery](https://github.com/synackuk/libirecovery)
 * libimobiledevice
 * libusb (if on linux)
+* [bin2c](https://github.com/gwilymk/bin2c) in the path
+* theos


### PR DESCRIPTION
I noticed that when I tried to compile not all deps were fullfilled, I needed to go to an older commit to find out the deps so this should add them back to the readme.